### PR TITLE
Improve TaskEditView UX

### DIFF
--- a/Common/UIApplication+Extensions.swift
+++ b/Common/UIApplication+Extensions.swift
@@ -1,0 +1,16 @@
+//
+//  UIApplication+Extensions.swift
+//  Done Pomodoro
+//
+//  Created by Eliab Sisay on 6/8/25.
+//
+
+import UIKit
+
+extension UIApplication {
+    /// Ends editing across the app, dismissing the keyboard.
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+

--- a/Modules/TaskManagement/TaskEditView.swift
+++ b/Modules/TaskManagement/TaskEditView.swift
@@ -45,6 +45,9 @@ struct TaskEditView: View {
     @State private var dailyGoal: Double = 8
     @State private var startBreaksAutomatically: Bool = false
     @State private var startWorkSessionsAutomatically: Bool = false
+
+    // Track focus state for the task name field
+    @FocusState private var isNameFieldFocused: Bool
     
     // Available colors to choose from
     private let colorOptions: [Color] = [.red, .orange, .yellow, .green, .blue, .indigo, .purple, .pink]
@@ -65,8 +68,9 @@ struct TaskEditView: View {
         NavigationView {
             Form {
                 // Task name section
-                Section(header: Text("Task Details")) {
+                Section(header: Text("Task Name")) {
                     TextField("Task Name", text: $name)
+                        .focused($isNameFieldFocused)
                 }
                 
                 // Color selection section
@@ -138,6 +142,15 @@ struct TaskEditView: View {
                 Section(header: Text("Automation")) {
                     Toggle("Auto-Start Breaks", isOn: $startBreaksAutomatically)
                     Toggle("Auto-Start Work Sessions", isOn: $startWorkSessionsAutomatically)
+                }
+            }
+            .onTapGesture {
+                // Dismiss the keyboard when tapping outside the text field
+                isNameFieldFocused = false
+            }
+            .onChange(of: isNameFieldFocused) { isFocused in
+                if !isFocused {
+                    UIApplication.shared.endEditing()
                 }
             }
             .navigationTitle(mode == .new ? "New Task" : "Edit Task")


### PR DESCRIPTION
## Summary
- rename Task Details header to Task Name
- dismiss keyboard when tapping outside name field
- add UIApplication extension for easy keyboard dismissal

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684316adda78832c816627669098aa26