### PR TITLE
Add unit tests for core timer and session logic

### DIFF
--- a/Done PomodoroTests/SessionManagerTests.swift
+++ b/Done PomodoroTests/SessionManagerTests.swift
@@ -1,0 +1,262 @@
+//
+//  SessionManagerTests.swift
+//  Done PomodoroTests
+//
+//  Tests for SessionManager: interval-credit rounding, session logging rules,
+//  next-session selection (short vs. long break), and auto-start decisions.
+//
+//  All tests use an in-memory Core Data store so nothing touches real user data.
+//
+
+import XCTest
+import UIKit
+@testable import Done_Pomodoro
+
+final class SessionManagerTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var persistence: PersistenceController!
+    private var sessionRepo: WorkSessionRepository!
+    private var taskRepo: TaskRepository!
+    private var manager: SessionManager!
+
+    // MARK: - Setup / Teardown
+
+    override func setUpWithError() throws {
+        // 🧪 Fresh in-memory store for every test — fully isolated from the app's real store
+        persistence = PersistenceController(inMemory: true)
+        let context = persistence.container.viewContext
+        sessionRepo = WorkSessionRepository(context: context)
+        taskRepo = TaskRepository(context: context)
+        manager = SessionManager(sessionRepo: sessionRepo)
+    }
+
+    override func tearDownWithError() throws {
+        manager = nil
+        taskRepo = nil
+        sessionRepo = nil
+        persistence = nil
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a standard test task (25/5/15, long break after 4) in the in-memory store.
+    private func makeTask(longBreakAfter: Int32 = 4,
+                          startBreaksAutomatically: Bool = false,
+                          startWorkSessionsAutomatically: Bool = false) throws -> Task {
+        let colorData = try NSKeyedArchiver.archivedData(withRootObject: UIColor.red,
+                                                         requiringSecureCoding: false)
+        return taskRepo.createTask(name: "Test Task",
+                                   color: colorData,
+                                   workDuration: 25,
+                                   shortBreakDuration: 5,
+                                   longBreakDuration: 15,
+                                   longBreakAfter: longBreakAfter,
+                                   dailyGoal: 4,
+                                   startBreaksAutomatically: startBreaksAutomatically,
+                                   startWorkSessionsAutomatically: startWorkSessionsAutomatically)
+    }
+
+    /// Logs a work session that ran for `fraction` of `totalDuration` seconds.
+    /// Uses explicit start/end dates so there is zero timing flakiness.
+    private func logSession(for task: Task,
+                            fraction: Double,
+                            totalDuration: TimeInterval = 1000,
+                            type: SessionType = .work,
+                            intervalCount: Double? = nil) {
+        let end = Date()
+        let start = end.addingTimeInterval(-totalDuration * fraction)
+        manager.logCompletedSession(task: task,
+                                    start: start,
+                                    sessionType: type,
+                                    totalDuration: totalDuration,
+                                    intervalCount: intervalCount,
+                                    end: end)
+    }
+
+    // MARK: - Interval Credit Rounding (PRD thresholds: <50% → 0, ≥50% → 0.5, ≥80% → 1)
+
+    func testCreditBelowFiftyPercentIsNotLogged() throws {
+        let task = try makeTask()
+
+        // ⏱ 49% complete → no credit → session should NOT be saved
+        logSession(for: task, fraction: 0.49)
+
+        XCTAssertEqual(sessionRepo.getSessions(for: task).count, 0,
+                       "A session under 50% should earn no credit and not be logged")
+    }
+
+    func testCreditAtJustOverFiftyPercentIsHalfInterval() throws {
+        let task = try makeTask()
+
+        // ⏱ 51% complete → half credit (0.5)
+        logSession(for: task, fraction: 0.51)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.intervalCount, 0.5)
+    }
+
+    func testCreditJustUnderEightyPercentIsStillHalfInterval() throws {
+        let task = try makeTask()
+
+        // ⏱ 79% complete → still half credit (full credit starts at 80%)
+        logSession(for: task, fraction: 0.79)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.intervalCount, 0.5)
+    }
+
+    func testCreditAtOverEightyPercentIsFullInterval() throws {
+        let task = try makeTask()
+
+        // ⏱ 81% complete → full credit (1.0)
+        logSession(for: task, fraction: 0.81)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.intervalCount, 1.0)
+    }
+
+    func testFullSessionEarnsFullInterval() throws {
+        let task = try makeTask()
+
+        // ⏱ 100% complete → full credit (1.0)
+        logSession(for: task, fraction: 1.0)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.intervalCount, 1.0)
+    }
+
+    // MARK: - Explicit Interval Count (complete-task-from-paused-session flow)
+
+    func testExplicitIntervalCountOverridesCalculation() throws {
+        let task = try makeTask()
+
+        // ✅ Even though elapsed is tiny (1%), an explicit count of 1.0 must win
+        logSession(for: task, fraction: 0.01, intervalCount: 1.0)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.intervalCount, 1.0)
+    }
+
+    func testExplicitZeroIntervalCountIsNotLogged() throws {
+        let task = try makeTask()
+
+        // 🚫 Explicit zero credit → nothing saved
+        logSession(for: task, fraction: 1.0, intervalCount: 0)
+
+        XCTAssertEqual(sessionRepo.getSessions(for: task).count, 0)
+    }
+
+    // MARK: - Session Logging Rules
+
+    func testBreakSessionsAreNeverLogged() throws {
+        let task = try makeTask()
+
+        // 🚫 Breaks earn no interval credit even when fully completed
+        logSession(for: task, fraction: 1.0, type: .shortBreak)
+        logSession(for: task, fraction: 1.0, type: .longBreak)
+
+        XCTAssertEqual(sessionRepo.getSessions(for: task).count, 0,
+                       "Only work sessions should ever be logged")
+    }
+
+    func testDurationIsStoredInMinutes() throws {
+        let task = try makeTask()
+
+        // ⏱ 1200 seconds elapsed (96% of 1250) → stored duration should be 20 minutes
+        logSession(for: task, fraction: 0.96, totalDuration: 1250)
+
+        let sessions = sessionRepo.getSessions(for: task)
+        XCTAssertEqual(sessions.count, 1)
+        XCTAssertEqual(sessions.first?.duration ?? 0, 20.0, accuracy: 0.01,
+                       "WorkSession.duration is stored in minutes, not seconds")
+    }
+
+    func testCompletedWorkSessionsCounterIncrements() throws {
+        let task = try makeTask()
+
+        XCTAssertEqual(manager.completedWorkSessions, 0)
+
+        logSession(for: task, fraction: 1.0)
+        logSession(for: task, fraction: 1.0)
+
+        XCTAssertEqual(manager.completedWorkSessions, 2)
+    }
+
+    func testSkippedSessionDoesNotIncrementCounter() throws {
+        let task = try makeTask()
+
+        // 🚫 Under-50% session is skipped — counter must not move
+        logSession(for: task, fraction: 0.3)
+
+        XCTAssertEqual(manager.completedWorkSessions, 0)
+    }
+
+    // MARK: - Next Session Selection (longBreakAfter cadence)
+
+    func testShortBreakFollowsWorkBeforeCycleCompletes() throws {
+        let task = try makeTask(longBreakAfter: 4)
+
+        // 1 completed session → 1 % 4 != 0 → short break next
+        logSession(for: task, fraction: 1.0)
+
+        let (nextType, nextDuration) = manager.nextSession(after: .work, for: task)
+        XCTAssertEqual(nextType, .shortBreak)
+        XCTAssertEqual(nextDuration, TimeInterval(task.shortBreakDuration * 60))
+    }
+
+    func testLongBreakFollowsWorkWhenCycleCompletes() throws {
+        let task = try makeTask(longBreakAfter: 4)
+
+        // 4 completed sessions → 4 % 4 == 0 → long break next
+        for _ in 1...4 {
+            logSession(for: task, fraction: 1.0)
+        }
+
+        let (nextType, nextDuration) = manager.nextSession(after: .work, for: task)
+        XCTAssertEqual(nextType, .longBreak)
+        XCTAssertEqual(nextDuration, TimeInterval(task.longBreakDuration * 60))
+    }
+
+    func testWorkFollowsShortBreak() throws {
+        let task = try makeTask()
+
+        let (nextType, nextDuration) = manager.nextSession(after: .shortBreak, for: task)
+        XCTAssertEqual(nextType, .work)
+        XCTAssertEqual(nextDuration, TimeInterval(task.workDuration * 60))
+    }
+
+    func testWorkFollowsLongBreak() throws {
+        let task = try makeTask()
+
+        let (nextType, nextDuration) = manager.nextSession(after: .longBreak, for: task)
+        XCTAssertEqual(nextType, .work)
+        XCTAssertEqual(nextDuration, TimeInterval(task.workDuration * 60))
+    }
+
+    // MARK: - Auto-Start Decisions
+
+    func testShouldAutoStartRespectsBreakSetting() throws {
+        let autoBreaksTask = try makeTask(startBreaksAutomatically: true)
+        let manualBreaksTask = try makeTask(startBreaksAutomatically: false)
+
+        XCTAssertTrue(manager.shouldAutoStart(.shortBreak, for: autoBreaksTask))
+        XCTAssertTrue(manager.shouldAutoStart(.longBreak, for: autoBreaksTask))
+        XCTAssertFalse(manager.shouldAutoStart(.shortBreak, for: manualBreaksTask))
+        XCTAssertFalse(manager.shouldAutoStart(.longBreak, for: manualBreaksTask))
+    }
+
+    func testShouldAutoStartRespectsWorkSetting() throws {
+        let autoWorkTask = try makeTask(startWorkSessionsAutomatically: true)
+        let manualWorkTask = try makeTask(startWorkSessionsAutomatically: false)
+
+        XCTAssertTrue(manager.shouldAutoStart(.work, for: autoWorkTask))
+        XCTAssertFalse(manager.shouldAutoStart(.work, for: manualWorkTask))
+    }
+}

--- a/Done PomodoroTests/SessionRestorerTests.swift
+++ b/Done PomodoroTests/SessionRestorerTests.swift
@@ -1,0 +1,150 @@
+//
+//  SessionRestorerTests.swift
+//  Done PomodoroTests
+//
+//  Tests for SessionRestorer: restoring a persisted session from UserDefaults,
+//  the force-quit (app_clean_exit) discard rule, and expiry handling.
+//
+//  ⚠️ These tests read/write UserDefaults.standard (which SessionRestorer uses
+//  directly), so every key is snapshotted in setUp and restored in tearDown to
+//  avoid corrupting real app state in the test host.
+//
+
+import XCTest
+@testable import Done_Pomodoro
+
+final class SessionRestorerTests: XCTestCase {
+
+    // MARK: - Properties
+
+    /// The exact key SessionRestorer/app lifecycle use for the clean-exit flag.
+    private let cleanExitKey = "app_clean_exit"
+
+    /// All UserDefaults keys these tests touch.
+    private var touchedKeys: [String] {
+        [cleanExitKey,
+         Constants.UserDefaultsKeys.activeSessionStartDate,
+         Constants.UserDefaultsKeys.activeSessionDuration,
+         Constants.UserDefaultsKeys.activeSessionType]
+    }
+
+    /// Snapshot of pre-test values so tearDown can put everything back.
+    private var snapshot: [String: Any] = [:]
+
+    // MARK: - Setup / Teardown
+
+    override func setUpWithError() throws {
+        // 📸 Snapshot current values, then start each test from a clean slate
+        snapshot = [:]
+        for key in touchedKeys {
+            snapshot[key] = UserDefaults.standard.object(forKey: key)
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        // ♻️ Restore the pre-test UserDefaults state
+        for key in touchedKeys {
+            if let value = snapshot[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Writes a complete persisted-session record, started `elapsed` seconds ago.
+    private func persistSession(elapsed: TimeInterval,
+                                duration: TimeInterval,
+                                type: String = SessionType.work.rawValue) {
+        UserDefaults.standard.set(Date().addingTimeInterval(-elapsed),
+                                  forKey: Constants.UserDefaultsKeys.activeSessionStartDate)
+        UserDefaults.standard.set(duration,
+                                  forKey: Constants.UserDefaultsKeys.activeSessionDuration)
+        UserDefaults.standard.set(type,
+                                  forKey: Constants.UserDefaultsKeys.activeSessionType)
+    }
+
+    // MARK: - Force-Quit Discard Rule
+
+    func testForceQuitDisablesRestoreAndClearsSessionData() throws {
+        // 💥 Simulate a force-quit: clean-exit flag is false but session data exists
+        UserDefaults.standard.set(false, forKey: cleanExitKey)
+        persistSession(elapsed: 60, duration: 1500)
+
+        XCTAssertFalse(SessionRestorer.hasPersistedSession,
+                       "Force-quit (no clean exit) must disable session restoration")
+
+        // 🧹 The stale session data should also have been cleared
+        XCTAssertNil(UserDefaults.standard.object(forKey: Constants.UserDefaultsKeys.activeSessionStartDate))
+        XCTAssertNil(UserDefaults.standard.object(forKey: Constants.UserDefaultsKeys.activeSessionDuration))
+        XCTAssertNil(UserDefaults.standard.object(forKey: Constants.UserDefaultsKeys.activeSessionType))
+    }
+
+    // MARK: - Happy-Path Restore
+
+    func testRestoreReturnsSessionWithCorrectRemainingTime() throws {
+        // ✅ Clean exit + a 25-minute work session that started 5 minutes ago
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+        persistSession(elapsed: 300, duration: 1500)
+
+        XCTAssertTrue(SessionRestorer.hasPersistedSession)
+
+        let restored = try XCTUnwrap(SessionRestorer.restore(),
+                                     "A valid in-progress session should restore")
+        XCTAssertEqual(restored.sessionType, .work)
+        XCTAssertEqual(restored.totalDuration, 1500)
+        // ⏳ ~1200 seconds should remain (generous tolerance for test execution time)
+        XCTAssertEqual(restored.timeRemaining, 1200, accuracy: 5)
+    }
+
+    func testRestoreHandlesBreakSessions() throws {
+        // ✅ Break sessions restore too, with the right type
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+        persistSession(elapsed: 30, duration: 300, type: SessionType.shortBreak.rawValue)
+
+        let restored = try XCTUnwrap(SessionRestorer.restore())
+        XCTAssertEqual(restored.sessionType, .shortBreak)
+    }
+
+    // MARK: - Expiry
+
+    func testExpiredSessionIsNotRestored() throws {
+        // ⌛️ A 10-minute session that started 30 minutes ago has fully expired
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+        persistSession(elapsed: 1800, duration: 600)
+
+        XCTAssertNil(SessionRestorer.restore(),
+                     "An expired session should not be restored")
+    }
+
+    // MARK: - Missing / Invalid Data
+
+    func testHasPersistedSessionIsFalseWhenDataIncomplete() throws {
+        // ✅ Clean exit, but only a start date — no duration or type
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+        UserDefaults.standard.set(Date(), forKey: Constants.UserDefaultsKeys.activeSessionStartDate)
+
+        XCTAssertFalse(SessionRestorer.hasPersistedSession,
+                       "All three session keys must exist for a restorable session")
+        XCTAssertNil(SessionRestorer.restore())
+    }
+
+    func testRestoreReturnsNilWhenNoDataExists() throws {
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+
+        XCTAssertFalse(SessionRestorer.hasPersistedSession)
+        XCTAssertNil(SessionRestorer.restore())
+    }
+
+    func testRestoreReturnsNilForUnknownSessionType() throws {
+        // 🧨 A corrupted/unknown session type string must not restore
+        UserDefaults.standard.set(true, forKey: cleanExitKey)
+        persistSession(elapsed: 60, duration: 1500, type: "notARealSessionType")
+
+        XCTAssertNil(SessionRestorer.restore(),
+                     "An unrecognized session type should fail the restore gracefully")
+    }
+}

--- a/Done PomodoroTests/TimerServiceTests.swift
+++ b/Done PomodoroTests/TimerServiceTests.swift
@@ -1,0 +1,120 @@
+//
+//  TimerServiceTests.swift
+//  Done PomodoroTests
+//
+//  Tests for TimerService: state transitions, guard conditions, and the
+//  timestamp-based countdown (the design decision that keeps the timer accurate
+//  across backgrounding — elapsed time derives from absolute dates, not ticks).
+//
+//  ⏱ The accuracy tests spin the main run loop for a second or two so the
+//  internal Timer can fire. Tolerances are generous to avoid CI flakiness.
+//
+
+import XCTest
+@testable import Done_Pomodoro
+
+final class TimerServiceTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var timerService: TimerService!
+
+    // MARK: - Setup / Teardown
+
+    override func setUpWithError() throws {
+        timerService = TimerService()
+    }
+
+    override func tearDownWithError() throws {
+        timerService.stop()
+        timerService = nil
+    }
+
+    // MARK: - Helpers
+
+    /// Spins the main run loop so the service's internal Timer can tick.
+    private func spinRunLoop(for seconds: TimeInterval) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    // MARK: - State Transitions
+
+    func testStartSetsUpRunningSession() throws {
+        timerService.start(duration: 1500, type: .work)
+
+        XCTAssertEqual(timerService.state, .running)
+        XCTAssertEqual(timerService.sessionType, .work)
+        XCTAssertEqual(timerService.timeRemaining, 1500)
+    }
+
+    func testPauseOnlyWorksWhileRunning() throws {
+        // 🚫 Pausing a stopped timer should do nothing
+        timerService.pause()
+        XCTAssertEqual(timerService.state, .stopped)
+
+        // ✅ Pausing a running timer works
+        timerService.start(duration: 1500, type: .work)
+        timerService.pause()
+        XCTAssertEqual(timerService.state, .paused)
+    }
+
+    func testResumeOnlyWorksWhilePaused() throws {
+        // 🚫 Resuming a running (not paused) timer should not change state
+        timerService.start(duration: 1500, type: .work)
+        timerService.resume()
+        XCTAssertEqual(timerService.state, .running)
+
+        // ✅ Resume after pause returns to running
+        timerService.pause()
+        timerService.resume()
+        XCTAssertEqual(timerService.state, .running)
+    }
+
+    func testStopResetsTimer() throws {
+        timerService.start(duration: 1500, type: .shortBreak)
+        timerService.stop()
+
+        XCTAssertEqual(timerService.state, .stopped)
+        XCTAssertEqual(timerService.timeRemaining, 0)
+    }
+
+    // MARK: - Timestamp-Based Countdown Accuracy
+
+    func testCountdownTracksElapsedWallClockTime() throws {
+        // ⏱ Start a 10-second timer and let ~2 seconds of real time pass
+        timerService.start(duration: 10, type: .work)
+        spinRunLoop(for: 2.1)
+
+        // Remaining should be ~8 seconds (derived from the start timestamp)
+        XCTAssertEqual(timerService.timeRemaining, 8, accuracy: 1.5,
+                       "timeRemaining should track wall-clock elapsed time")
+    }
+
+    func testPausedTimeIsNotCountedAgainstTheSession() throws {
+        // ⏱ Run for ~1s, pause for 1s, resume for ~1s → only ~2s of active time
+        timerService.start(duration: 10, type: .work)
+        spinRunLoop(for: 1.1)
+
+        timerService.pause()
+        let remainingAtPause = timerService.timeRemaining
+        Thread.sleep(forTimeInterval: 1.0) // Paused wall-clock time — must not count
+
+        timerService.resume()
+        spinRunLoop(for: 1.1)
+
+        // If the paused second were (wrongly) counted, remaining would be ~7.
+        // Correct behavior: ~8 seconds remain (10 - ~2 active seconds).
+        XCTAssertEqual(timerService.timeRemaining, remainingAtPause - 1.1, accuracy: 1.0,
+                       "Pause duration must be excluded from elapsed time (start date is shifted on resume)")
+    }
+
+    func testTimerStopsItselfAtZero() throws {
+        // ⏱ A 1-second timer should complete and reset itself
+        timerService.start(duration: 1, type: .work)
+        spinRunLoop(for: 2.5)
+
+        XCTAssertEqual(timerService.state, .stopped,
+                       "Timer should stop itself when it reaches zero")
+        XCTAssertEqual(timerService.timeRemaining, 0)
+    }
+}

--- a/Done PomodoroTests/WorkSessionRepositoryTests.swift
+++ b/Done PomodoroTests/WorkSessionRepositoryTests.swift
@@ -1,0 +1,161 @@
+//
+//  WorkSessionRepositoryTests.swift
+//  Done PomodoroTests
+//
+//  Tests for WorkSessionRepository: CRUD, per-task fetches, and the
+//  date-range query that powers "All Tasks" reports (Decision: report totals
+//  come from one getAllSessionsInRange call, not per-task summation — these
+//  tests guard the equivalence of the two approaches).
+//
+//  All tests use an in-memory Core Data store so nothing touches real user data.
+//
+
+import XCTest
+import UIKit
+@testable import Done_Pomodoro
+
+final class WorkSessionRepositoryTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var persistence: PersistenceController!
+    private var sessionRepo: WorkSessionRepository!
+    private var taskRepo: TaskRepository!
+
+    // MARK: - Setup / Teardown
+
+    override func setUpWithError() throws {
+        // 🧪 Fresh in-memory store for every test
+        persistence = PersistenceController(inMemory: true)
+        let context = persistence.container.viewContext
+        sessionRepo = WorkSessionRepository(context: context)
+        taskRepo = TaskRepository(context: context)
+    }
+
+    override func tearDownWithError() throws {
+        taskRepo = nil
+        sessionRepo = nil
+        persistence = nil
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a simple test task in the in-memory store.
+    private func makeTask(name: String = "Test Task") throws -> Task {
+        let colorData = try NSKeyedArchiver.archivedData(withRootObject: UIColor.blue,
+                                                         requiringSecureCoding: false)
+        return taskRepo.createTask(name: name,
+                                   color: colorData,
+                                   workDuration: 25,
+                                   shortBreakDuration: 5,
+                                   longBreakDuration: 15,
+                                   longBreakAfter: 4,
+                                   dailyGoal: 4,
+                                   startBreaksAutomatically: false,
+                                   startWorkSessionsAutomatically: false)
+    }
+
+    /// Creates a completed work session for `task` starting at `startTime`.
+    @discardableResult
+    private func makeSession(for task: Task,
+                             startTime: Date,
+                             intervalCount: Double = 1.0,
+                             duration: Double = 25) -> WorkSession? {
+        sessionRepo.createSession(for: task,
+                                  startTime: startTime,
+                                  type: SessionType.work.rawValue,
+                                  isPaused: false,
+                                  isCompleted: true,
+                                  duration: duration,
+                                  intervalCount: intervalCount,
+                                  pauseTime: nil,
+                                  totalPauseDuration: 0)
+    }
+
+    // MARK: - Create & Fetch
+
+    func testCreateSessionPersistsAllFields() throws {
+        let task = try makeTask()
+        let start = Date()
+
+        let session = try XCTUnwrap(makeSession(for: task, startTime: start,
+                                                intervalCount: 0.5, duration: 12.5))
+
+        XCTAssertNotNil(session.id)
+        XCTAssertEqual(session.startTime, start)
+        XCTAssertEqual(session.type, SessionType.work.rawValue)
+        XCTAssertEqual(session.intervalCount, 0.5)
+        XCTAssertEqual(session.duration, 12.5)
+        XCTAssertTrue(session.isCompleted)
+        XCTAssertEqual(session.task, task, "Session must be linked to its parent task")
+    }
+
+    func testGetSessionsFiltersByTaskAndSortsNewestFirst() throws {
+        let taskA = try makeTask(name: "Task A")
+        let taskB = try makeTask(name: "Task B")
+        let now = Date()
+
+        // 📋 Two sessions for A (older + newer), one for B
+        makeSession(for: taskA, startTime: now.addingTimeInterval(-3600))
+        makeSession(for: taskA, startTime: now)
+        makeSession(for: taskB, startTime: now)
+
+        let sessionsA = sessionRepo.getSessions(for: taskA)
+        XCTAssertEqual(sessionsA.count, 2, "Only Task A's sessions should be returned")
+        XCTAssertEqual(sessionsA.first?.startTime, now,
+                       "Sessions should be sorted newest first")
+    }
+
+    // MARK: - Date-Range Query (powers "All Tasks" reports)
+
+    func testGetAllSessionsInRangeIncludesBoundariesAndExcludesOutside() throws {
+        let task = try makeTask()
+        let rangeStart = Date().addingTimeInterval(-7200) // 2 hours ago
+        let rangeEnd = Date()
+
+        // 📋 Sessions exactly on both boundaries, inside, and outside the range
+        makeSession(for: task, startTime: rangeStart)                          // on start boundary
+        makeSession(for: task, startTime: rangeStart.addingTimeInterval(600))  // inside
+        makeSession(for: task, startTime: rangeEnd)                            // on end boundary
+        makeSession(for: task, startTime: rangeStart.addingTimeInterval(-600)) // before range
+        makeSession(for: task, startTime: rangeEnd.addingTimeInterval(600))    // after range
+
+        let inRange = sessionRepo.getAllSessionsInRange(from: rangeStart, to: rangeEnd)
+        XCTAssertEqual(inRange.count, 3,
+                       "Range query should be inclusive of both boundaries and exclude outside sessions")
+    }
+
+    func testAllTasksRangeQueryMatchesPerTaskSummation() throws {
+        // 🛡 Regression guard for the report-totals fix: one range query across
+        // all tasks must equal the sum of per-task results.
+        let taskA = try makeTask(name: "Task A")
+        let taskB = try makeTask(name: "Task B")
+        let now = Date()
+
+        makeSession(for: taskA, startTime: now.addingTimeInterval(-300), intervalCount: 1.0)
+        makeSession(for: taskA, startTime: now.addingTimeInterval(-200), intervalCount: 0.5)
+        makeSession(for: taskB, startTime: now.addingTimeInterval(-100), intervalCount: 1.0)
+
+        let rangeTotal = sessionRepo
+            .getAllSessionsInRange(from: now.addingTimeInterval(-3600), to: now)
+            .reduce(0) { $0 + $1.intervalCount }
+
+        let perTaskTotal = (sessionRepo.getSessions(for: taskA) + sessionRepo.getSessions(for: taskB))
+            .reduce(0) { $0 + $1.intervalCount }
+
+        XCTAssertEqual(rangeTotal, 2.5)
+        XCTAssertEqual(rangeTotal, perTaskTotal,
+                       "All-tasks range query and per-task summation must agree")
+    }
+
+    // MARK: - Delete
+
+    func testDeleteSessionRemovesIt() throws {
+        let task = try makeTask()
+        let session = try XCTUnwrap(makeSession(for: task, startTime: Date()))
+
+        sessionRepo.deleteSession(session)
+
+        XCTAssertEqual(sessionRepo.getSessions(for: task).count, 0)
+    }
+}


### PR DESCRIPTION
## Summary

First meaningful test coverage for the app, targeting the riskiest untested code identified in the project handoff: timer accuracy, interval-credit rounding, session restoration, and report aggregation queries.

**36 new tests, all passing** on iPhone 17 / iOS 26.3 simulator. No app code changes — tests only.

## Coverage

| Suite | What it locks down |
|---|---|
| `SessionManagerTests` (17) | PRD rounding thresholds (<50% → 0, ≥50% → 0.5, ≥80% → 1), explicit interval-count override (complete-from-pause flow), breaks never logged, long-break cadence (`longBreakAfter`), auto-start decisions |
| `SessionRestorerTests` (7) | Force-quit discard rule (`app_clean_exit`), remaining-time math on restore, expired-session rejection, missing/corrupt data handling |
| `TimerServiceTests` (7) | State-transition guards, timestamp-based countdown tracks wall-clock time, paused time excluded from elapsed, self-stop at zero |
| `WorkSessionRepositoryTests` (5) | CRUD + task relationship, newest-first sort, inclusive range-query boundaries, all-tasks range query ≡ per-task summation (regression guard for the report-totals fix) |

## Test design notes

- Core Data tests run against fresh **in-memory stores** per test — never touches real data
- `SessionRestorerTests` snapshots and restores every `UserDefaults` key it touches
- Timer accuracy tests spin the run loop ~6s total with generous tolerances to stay CI-safe
- No project file changes needed — the test target is a filesystem-synchronized group

🤖 Generated with [Claude Code](https://claude.com/claude-code)