### PR TITLE
Persist task-list sort preferences across launches

### DIFF
--- a/Common/Constants.swift
+++ b/Common/Constants.swift
@@ -28,6 +28,8 @@ enum Constants {
         static let activeSessionType = "activeSessionType"
         static let lastSelectedTaskID = "lastSelectedTaskID"
         static let shouldRestoreSession = "shouldRestoreSession"
+        static let todoSortOption = "todoSortOption"
+        static let doneSortOption = "doneSortOption"
     }
    
     /// App-specific label strings for session types

--- a/Done PomodoroTests/TaskListSortPersistenceTests.swift
+++ b/Done PomodoroTests/TaskListSortPersistenceTests.swift
@@ -1,0 +1,104 @@
+//
+//  TaskListSortPersistenceTests.swift
+//  Done PomodoroTests
+//
+//  Tests that the To-Do and Done list sort selections persist across launches.
+//  A "launch" is simulated by creating a fresh TaskListViewModel — the bug was
+//  that sort options reset to their defaults every time the view model was
+//  recreated because they were never written to / read from UserDefaults.
+//
+//  ⚠️ These tests read/write UserDefaults.standard (the production store the
+//  view model uses), so the two sort keys are snapshotted in setUp and restored
+//  in tearDown to avoid corrupting real app state in the test host.
+//
+
+import XCTest
+@testable import Done_Pomodoro
+
+final class TaskListSortPersistenceTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var touchedKeys: [String] {
+        [Constants.UserDefaultsKeys.todoSortOption,
+         Constants.UserDefaultsKeys.doneSortOption]
+    }
+
+    private var snapshot: [String: Any] = [:]
+
+    // MARK: - Setup / Teardown
+
+    override func setUpWithError() throws {
+        // 📸 Snapshot + clear so each test starts from "nothing persisted yet"
+        snapshot = [:]
+        for key in touchedKeys {
+            snapshot[key] = UserDefaults.standard.object(forKey: key)
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        for key in touchedKeys {
+            if let value = snapshot[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
+    // MARK: - Defaults
+
+    func testFreshViewModelUsesDefaultSortOptionsWhenNothingPersisted() throws {
+        let viewModel = TaskListViewModel()
+
+        XCTAssertEqual(viewModel.todoSortOption, .creationDate,
+                       "To-Do list should default to Creation Date")
+        XCTAssertEqual(viewModel.doneSortOption, .completionDate,
+                       "Done list should default to Completion Date")
+    }
+
+    // MARK: - Persistence Across "Launches"
+
+    func testTodoSortOptionPersistsAcrossViewModelRecreation() throws {
+        // 🔧 First "launch": user changes the To-Do sort
+        let firstLaunch = TaskListViewModel()
+        firstLaunch.todoSortOption = .nameAZ
+
+        // 🔁 Second "launch": a brand-new view model should read the saved value
+        let secondLaunch = TaskListViewModel()
+        XCTAssertEqual(secondLaunch.todoSortOption, .nameAZ,
+                       "To-Do sort selection should survive recreation")
+    }
+
+    func testDoneSortOptionPersistsAcrossViewModelRecreation() throws {
+        let firstLaunch = TaskListViewModel()
+        firstLaunch.doneSortOption = .nameZA
+
+        let secondLaunch = TaskListViewModel()
+        XCTAssertEqual(secondLaunch.doneSortOption, .nameZA,
+                       "Done sort selection should survive recreation")
+    }
+
+    func testBothSortOptionsAreTrackedIndependently() throws {
+        let firstLaunch = TaskListViewModel()
+        firstLaunch.todoSortOption = .nameZA
+        firstLaunch.doneSortOption = .creationDate
+
+        let secondLaunch = TaskListViewModel()
+        XCTAssertEqual(secondLaunch.todoSortOption, .nameZA)
+        XCTAssertEqual(secondLaunch.doneSortOption, .creationDate)
+    }
+
+    // MARK: - Raw Persistence Format
+
+    func testSortOptionIsStoredAsItsRawValueString() throws {
+        let viewModel = TaskListViewModel()
+        viewModel.todoSortOption = .nameAZ
+
+        // The persisted form should be the enum's rawValue, matching the
+        // pattern used elsewhere (e.g. report settings).
+        let stored = UserDefaults.standard.string(forKey: Constants.UserDefaultsKeys.todoSortOption)
+        XCTAssertEqual(stored, TodoSortOption.nameAZ.rawValue)
+    }
+}

--- a/Modules/TaskManagement/TaskListViewModel.swift
+++ b/Modules/TaskManagement/TaskListViewModel.swift
@@ -44,9 +44,18 @@ final class TaskListViewModel: ObservableObject {
     @Published var showTaskCompletedOverlay: Bool = false
     @Published var lastCompletedTask: Task? = nil
     
-    /// Sorting options
-    @Published var todoSortOption: TodoSortOption = .creationDate
-    @Published var doneSortOption: DoneSortOption = .completionDate
+    /// Sorting options — persisted to UserDefaults so the user's choice
+    /// survives relaunch (matches the report-settings persistence pattern).
+    @Published var todoSortOption: TodoSortOption = .creationDate {
+        didSet {
+            UserDefaults.standard.set(todoSortOption.rawValue, forKey: Constants.UserDefaultsKeys.todoSortOption)
+        }
+    }
+    @Published var doneSortOption: DoneSortOption = .completionDate {
+        didSet {
+            UserDefaults.standard.set(doneSortOption.rawValue, forKey: Constants.UserDefaultsKeys.doneSortOption)
+        }
+    }
     
     /// Alert properties for custom AlertView
     @Published var showingAlertView = false
@@ -68,9 +77,12 @@ final class TaskListViewModel: ObservableObject {
     // MARK: - Initialization and Cleanup
     
     init() {
+        // Restore the user's saved sort selections before anything observes them
+        loadSortOptions()
+
         // Load tasks initially
         loadTasks()
-        
+
         // Set up observer for task selection events
         taskSelectedObserver = AppEvents.observe(AppEvents.taskSelected) { [weak self] _ in
             // Refresh the task list to update the indicators
@@ -89,6 +101,22 @@ final class TaskListViewModel: ObservableObject {
         }
     }
     
+    // MARK: - Sort Persistence
+
+    /// Restores the persisted sort selections from UserDefaults.
+    /// Falls back to the declared defaults when nothing valid is stored.
+    private func loadSortOptions() {
+        if let raw = UserDefaults.standard.string(forKey: Constants.UserDefaultsKeys.todoSortOption),
+           let option = TodoSortOption(rawValue: raw) {
+            todoSortOption = option
+        }
+        if let raw = UserDefaults.standard.string(forKey: Constants.UserDefaultsKeys.doneSortOption),
+           let option = DoneSortOption(rawValue: raw) {
+            doneSortOption = option
+        }
+        print("🔃 Restored sort options — To-Do: \(todoSortOption.rawValue), Done: \(doneSortOption.rawValue)")
+    }
+
     // MARK: - Task Access
     
     /// Returns only the incomplete tasks, sorted according to the selected option


### PR DESCRIPTION
## Summary

Fixes the known bug where the To-Do and Done list sort selections reset to their defaults every time the app launches. `TaskListViewModel` held the sort options only in memory, so recreating the view model (i.e. relaunching) lost the user's choice.

They now persist to UserDefaults — saved on change, restored on init — following the exact pattern the Reports module already uses for its view settings.

## Changes

- `Constants.UserDefaultsKeys`: add `todoSortOption` / `doneSortOption`.
- `TaskListViewModel`: `didSet` saves each option's `rawValue`; `loadSortOptions()` restores them in `init` with a guard-let fallback to the declared defaults (so an unset/corrupt value is safe).

## Tests (written test-first)

5 new tests in `TaskListSortPersistenceTests`, all passing; the 4 persistence ones were confirmed **RED before the fix, GREEN after**:

- Fresh view model uses defaults when nothing is stored
- To-Do / Done options each survive view-model recreation
- The two options are tracked independently
- Stored form is the enum `rawValue` (matches report-settings format)

Full suite: **43 passing, 0 failing** locally. CI will re-verify.

## Note

Like the existing report-settings keys, these view-specific options are intentionally **not** registered in `SettingsService.registerDefaults()` — the guard-let fallback covers the unset case (verified by the defaults test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)