### PR TITLE
Notification sounds: ship Default/None, fix silent-none and dead options

### DIFF
--- a/App Core/SettingsService.swift
+++ b/App Core/SettingsService.swift
@@ -26,8 +26,8 @@ final class SettingsService {
             Constants.UserDefaultsKeys.hasCompletedOnboarding: false,
             Constants.UserDefaultsKeys.hideStatusBar: false,
             Constants.UserDefaultsKeys.preventSleep: false,
-            Constants.UserDefaultsKeys.workCompletedSound: "ding",
-            Constants.UserDefaultsKeys.breakCompletedSound: "chime",
+            Constants.UserDefaultsKeys.workCompletedSound: "default",
+            Constants.UserDefaultsKeys.breakCompletedSound: "default",
             Constants.UserDefaultsKeys.pushNotificationsEnabled: true,
         ])
     }
@@ -58,12 +58,12 @@ final class SettingsService {
     }
     
     var workCompletedSound: String {
-        get { defaults.string(forKey: Constants.UserDefaultsKeys.workCompletedSound) ?? "ding" }
+        get { defaults.string(forKey: Constants.UserDefaultsKeys.workCompletedSound) ?? "default" }
         set { defaults.set(newValue, forKey: Constants.UserDefaultsKeys.workCompletedSound) }
     }
-    
+
     var breakCompletedSound: String {
-        get { defaults.string(forKey: Constants.UserDefaultsKeys.breakCompletedSound) ?? "chime" }
+        get { defaults.string(forKey: Constants.UserDefaultsKeys.breakCompletedSound) ?? "default" }
         set { defaults.set(newValue, forKey: Constants.UserDefaultsKeys.breakCompletedSound) }
     }
     

--- a/Done PomodoroTests/NotificationSoundTests.swift
+++ b/Done PomodoroTests/NotificationSoundTests.swift
@@ -1,0 +1,101 @@
+//
+//  NotificationSoundTests.swift
+//  Done PomodoroTests
+//
+//  Tests for notification sound resolution after the move to a Default/None
+//  model. The previous code offered sound names ("chime", "bell", "marimba")
+//  that mapped to .caf files which were never bundled — so those options
+//  played nothing deliberate, and "none" still produced the default sound.
+//
+//  Now: "none" → silent (nil), everything else → the system default sound.
+//  Legacy stored values are coerced to "default" by SettingsViewModel.
+//
+//  ⚠️ The normalization tests read/write UserDefaults.standard, so the two
+//  sound keys are snapshotted in setUp and restored in tearDown.
+//
+
+import XCTest
+import UserNotifications
+@testable import Done_Pomodoro
+
+final class NotificationSoundTests: XCTestCase {
+
+    // MARK: - getSoundFor mapping
+
+    func testNoneResolvesToSilentNil() {
+        XCTAssertNil(NotificationService.shared.getSoundFor(name: "none"),
+                     "'none' must produce no sound (a silent banner)")
+    }
+
+    func testDefaultResolvesToSystemDefaultSound() {
+        XCTAssertEqual(NotificationService.shared.getSoundFor(name: "default"), .default)
+    }
+
+    func testLegacySoundNamesFallBackToDefault() {
+        // Names that used to point at missing .caf files must now degrade to
+        // the system default sound rather than silence-by-accident.
+        for legacy in ["ding", "chime", "bell", "marimba", "swoosh", "completed", "anything"] {
+            XCTAssertEqual(NotificationService.shared.getSoundFor(name: legacy), .default,
+                           "Unrecognized '\(legacy)' should fall back to the default sound")
+        }
+    }
+
+    // MARK: - supportedSounds invariant
+
+    func testSupportedSoundsIsDefaultAndNone() {
+        XCTAssertEqual(SettingsViewModel.supportedSounds, ["default", "none"])
+    }
+
+    // MARK: - Legacy value normalization in SettingsViewModel
+
+    private var soundKeys: [String] {
+        [Constants.UserDefaultsKeys.workCompletedSound,
+         Constants.UserDefaultsKeys.breakCompletedSound]
+    }
+    private var snapshot: [String: Any] = [:]
+
+    override func setUpWithError() throws {
+        snapshot = [:]
+        for key in soundKeys {
+            snapshot[key] = UserDefaults.standard.object(forKey: key)
+        }
+    }
+
+    override func tearDownWithError() throws {
+        for key in soundKeys {
+            if let value = snapshot[key] {
+                UserDefaults.standard.set(value, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
+    @MainActor
+    func testLegacyStoredSoundIsCoercedToDefault() {
+        // Simulate a user who saved "chime" before custom sounds were removed.
+        UserDefaults.standard.set("chime", forKey: Constants.UserDefaultsKeys.workCompletedSound)
+        UserDefaults.standard.set("marimba", forKey: Constants.UserDefaultsKeys.breakCompletedSound)
+
+        let viewModel = SettingsViewModel()
+
+        // The picker-facing values are valid options...
+        XCTAssertEqual(viewModel.workCompletedSound, "default")
+        XCTAssertEqual(viewModel.breakCompletedSound, "default")
+
+        // ...and the coercion is persisted so it doesn't recur.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.UserDefaultsKeys.workCompletedSound), "default")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: Constants.UserDefaultsKeys.breakCompletedSound), "default")
+    }
+
+    @MainActor
+    func testValidStoredSoundIsPreserved() {
+        UserDefaults.standard.set("none", forKey: Constants.UserDefaultsKeys.workCompletedSound)
+        UserDefaults.standard.set("default", forKey: Constants.UserDefaultsKeys.breakCompletedSound)
+
+        let viewModel = SettingsViewModel()
+
+        XCTAssertEqual(viewModel.workCompletedSound, "none")
+        XCTAssertEqual(viewModel.breakCompletedSound, "default")
+    }
+}

--- a/Modules/Settings/SettingViewModel.swift
+++ b/Modules/Settings/SettingViewModel.swift
@@ -68,19 +68,35 @@ final class SettingsViewModel: ObservableObject {
     private let settingsService = SettingsService.shared
     private let notificationService = NotificationService.shared
     
-    /// Available sound options for session completion
-    let availableSounds = ["ding", "chime", "bell", "marimba", "none"]
+    /// Single source of truth for the selectable sound options.
+    /// iOS local notifications only support the system default sound or a
+    /// bundled custom file; until custom sounds are bundled, we offer the
+    /// honest set: the default sound, or none (a silent banner).
+    /// Keep this in sync with `NotificationService.getSoundFor`.
+    static let supportedSounds = ["default", "none"]
+
+    /// Available sound options for session completion (drives the Settings pickers).
+    let availableSounds = SettingsViewModel.supportedSounds
     
     // MARK: - Init
     
     init() {
-        // Initialize published properties from stored settings
+        // Initialize published properties from stored settings.
+        // Legacy sound values (e.g. "ding"/"chime" from before custom sounds
+        // were removed) are coerced to "default" so the pickers show a valid
+        // selection instead of a blank.
         self.appearanceMode = settingsService.appearanceMode
         self.preventSleep = settingsService.preventSleep
-        self.workCompletedSound = settingsService.workCompletedSound
-        self.breakCompletedSound = settingsService.breakCompletedSound
+        self.workCompletedSound = SettingsViewModel.supportedSounds.contains(settingsService.workCompletedSound)
+            ? settingsService.workCompletedSound : "default"
+        self.breakCompletedSound = SettingsViewModel.supportedSounds.contains(settingsService.breakCompletedSound)
+            ? settingsService.breakCompletedSound : "default"
         self.pushNotificationsEnabled = settingsService.pushNotificationsEnabled
-        
+
+        // Persist any coercion above so the stored value matches what's shown.
+        settingsService.workCompletedSound = workCompletedSound
+        settingsService.breakCompletedSound = breakCompletedSound
+
         print("📱 Settings loaded:")
         print("- Appearance Mode: \(appearanceMode.rawValue)")
         print("- Prevent Sleep: \(preventSleep)")

--- a/Notifications/NotificationService.swift
+++ b/Notifications/NotificationService.swift
@@ -53,12 +53,13 @@ final class NotificationService {
     func scheduleNotification(in seconds: TimeInterval,
                               title: String,
                               body: String,
-                              sound: UNNotificationSound = .default,
+                              sound: UNNotificationSound? = .default,
                               categoryIdentifier: String = "timerComplete") {
-        
+
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
+        // Leaving `sound` nil produces a silent banner (the "none" option).
         content.sound = sound
         content.categoryIdentifier = categoryIdentifier
         
@@ -76,24 +77,20 @@ final class NotificationService {
         }
     }
     
-    /// Returns a notification sound based on the provided sound name.
-    /// - Parameter name: The name of the sound to use
-    /// - Returns: A UNNotificationSound object
-    func getSoundFor(name: String) -> UNNotificationSound {
-        // Map the string setting to actual sound files
+    /// Returns the notification sound for a stored sound-setting name.
+    /// - Parameter name: The persisted sound setting (currently "default" or "none").
+    /// - Returns: `.default` for the system sound, or `nil` for a silent notification.
+    ///
+    /// Any unrecognized value (including legacy names like "ding"/"chime" stored
+    /// before custom sounds were removed) safely falls back to the default sound.
+    /// When custom sounds are bundled later, add their cases here and keep this in
+    /// sync with `SettingViewModel.availableSounds`.
+    func getSoundFor(name: String) -> UNNotificationSound? {
         switch name {
-        case "ding":
-            return UNNotificationSound.default
-        case "chime":
-            return UNNotificationSound(named: UNNotificationSoundName("chime.caf"))
-        case "bell":
-            return UNNotificationSound(named: UNNotificationSoundName("bell.caf"))
-        case "swoosh":
-            return UNNotificationSound(named: UNNotificationSoundName("swoosh.caf"))
-        case "completed":
-            return UNNotificationSound(named: UNNotificationSoundName("completed.caf"))
+        case "none":
+            return nil
         default:
-            return UNNotificationSound.default
+            return .default
         }
     }
     


### PR DESCRIPTION
## Summary

Resolves the half-built notification-sound feature. The Settings picker offered five options (`ding`/`chime`/`bell`/`marimba`/`none`), but `NotificationService` mapped a *different* set — several to `.caf` files that were never bundled. The result: most options played nothing deliberate, and **'None' still played the default sound**.

iOS local notifications only support the system default sound or a bundled custom file — there's no built-in sound menu. So for v1 we ship the honest set: **Default or None.** (Per the decision, custom bundled sounds are intentionally deferred to a post-v1 enhancement.)

## Changes

- **`SettingsViewModel.supportedSounds = ["default", "none"]`** — a single source of truth that the pickers read. Legacy stored values (`ding`/`chime`/etc.) are coerced to `default` on load and persisted, so the picker never shows a blank selection. Keeping one list fixes the root cause: the original bug was two lists silently disagreeing.
- **`NotificationService.getSoundFor` now returns `UNNotificationSound?`** — `none` → `nil` (silent), everything else → `.default`. The dead `.caf` cases are gone.
- **`scheduleNotification`** leaves `content.sound` unset when `nil`, producing a genuinely silent banner.
- **`SettingsService`** defaults/getters updated `ding`/`chime` → `default`.

## Tests

6 new tests in `NotificationSoundTests`: `none`→nil, `default`→`.default`, legacy names→`.default`, the `supportedSounds` invariant, and the legacy-value coercion (with persistence). **Full suite: 49 passing, 0 failing.**

## Out of scope (separate follow-up)

This PR fixes *which sound plays*. Whether the end-of-session notification reliably fires and respects the `pushNotificationsEnabled` toggle is a separate concern flagged in the handoff — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)