### PR TITLE
Raise minimum deployment target to iOS 26 (Liquid Glass)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,23 +27,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Show selected Xcode
-        run: xcodebuild -version
+      # The app now targets iOS 26 (Liquid Glass), so CI needs an Xcode that
+      # ships the iOS 26 SDK. Select the newest installed Xcode; if none beats
+      # the default, fall back to it. Print versions + runtimes for diagnostics.
+      - name: Select newest Xcode
+        run: |
+          set -euo pipefail
+          NEWEST=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -n "$NEWEST" ]; then
+            echo "Selecting $NEWEST"
+            sudo xcode-select -s "$NEWEST/Contents/Developer"
+          fi
+          xcodebuild -version
+          echo "--- installed iOS runtimes ---"
+          xcrun simctl list runtimes | grep -i ios || true
 
-      # Pick a concrete iOS simulator at runtime so the workflow survives
-      # GitHub bumping the runner image (device names / OS versions drift).
-      # The project's deployment target is iOS 18.2, so any installed iPhone
-      # on the runner's bundled iOS 18+ runtime is valid.
-      - name: Select an iOS Simulator
+      # Pick a concrete iOS 26 simulator at runtime. The deployment target is
+      # iOS 26, so the test destination must be an iOS 26 runtime — an older
+      # runtime would fail to install the app.
+      - name: Select an iOS 26 Simulator
         run: |
           set -euo pipefail
           UDID=$(xcrun simctl list devices available --json \
             | python3 -c "import json,sys;
           data=json.load(sys.stdin)['devices'];
-          cands=[d for rt,ds in data.items() if 'iOS' in rt for d in ds if d['isAvailable'] and 'iPhone' in d['name']];
+          cands=[d for rt,ds in data.items() if 'iOS-26' in rt for d in ds if d['isAvailable'] and 'iPhone' in d['name']];
           print(cands[-1]['udid'] if cands else '')")
           if [ -z "$UDID" ]; then
-            echo "::error::No available iPhone simulator found on the runner"
+            echo "::error::No available iOS 26 iPhone simulator on the runner (the app requires iOS 26)."
             xcrun simctl list devices available
             exit 1
           fi

--- a/Done Pomodoro.xcodeproj/project.pbxproj
+++ b/Done Pomodoro.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -641,7 +641,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -667,7 +667,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -697,7 +697,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -719,7 +719,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HWB25859R2;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.eliabsisay.Done-PomodoroTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -738,7 +738,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HWB25859R2;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.eliabsisay.Done-PomodoroTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## What
Raises the app's minimum deployment target **iOS 18.2 → 26.0**, the foundational step before redesign PR1.

## Why
The visual redesign adopts Apple's true **iOS 26 Liquid Glass** (native `glassEffect`), which requires an iOS 26 minimum. Owner-approved. **Tradeoff: drops users on iOS 18–25.** Landed on its own so the CI/runner risk is isolated before the large design-system PR.

## Changes
- `project.pbxproj`: all six `IPHONEOS_DEPLOYMENT_TARGET` entries (project base, app target, test targets) → `26.0`. `plutil -lint` OK.
- `.github/workflows/ci.yml`: select the newest installed Xcode (must ship the iOS 26 SDK) and require an **iOS-26** iPhone simulator for the test destination, with clear diagnostics (Xcode version + installed runtimes) if the runner lacks either.

## Verification
- Local: build + full **57-test** unit suite green on the iOS 26 simulator (iPhone 17 Pro).
- CI: this PR is itself the check that the GitHub runner can build/test an iOS 26 project. Watching the run; if the runner lacks Xcode 26 / an iOS 26 runtime, the diagnostics will show it and the runner image will be adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)